### PR TITLE
Add deployment to GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,24 @@ Simply open [Lovable](https://lovable.dev/projects/0b193fdf-b7b1-4b5c-91f4-787cb
 ## I want to use a custom domain - is that possible?
 
 We don't support custom domains (yet). If you want to deploy your project under your own domain then we recommend using Netlify. Visit our docs for more details: [Custom domains](https://docs.lovable.dev/tips-tricks/custom-domain/)
+
+## How to deploy to GitHub Pages
+
+To deploy this project as a static site on GitHub Pages, follow these steps:
+
+1. Ensure you have `gh-pages` installed as a dependency. If not, you can add it by running:
+   ```sh
+   npm install gh-pages --save-dev
+   ```
+
+2. Build the project by running:
+   ```sh
+   npm run build
+   ```
+
+3. Deploy the `dist` directory to GitHub Pages by running:
+   ```sh
+   npm run deploy
+   ```
+
+Your site should now be live on GitHub Pages.

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.14"
+    "vite": "^5.4.14",
+    "gh-pages": "^5.0.0"
   }
 }


### PR DESCRIPTION
Add instructions for deploying the project to GitHub Pages.

* **README.md**
  - Add a section with step-by-step instructions for deploying to GitHub Pages.

* **package.json**
  - Add `gh-pages` as a dependency.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/salestracker/ai-empowered-visibility-61/pull/3?shareId=437af313-2bd9-4153-b7a5-1eaf26a74489).